### PR TITLE
v0.1.10

### DIFF
--- a/lib/jvertica/version.rb
+++ b/lib/jvertica/version.rb
@@ -1,3 +1,3 @@
 class Jvertica
-  VERSION = "0.1.9"
+  VERSION = "0.1.10"
 end


### PR DESCRIPTION
note:
- `method arg` => `method(arg)`
- Split files
- Add example script
- Error Class is inherited not from `StandardError` but `Jvertica::Error < StandardError`
- gitignore .bundle, .ruby-version
- write correct .travis.yml

contributed by @sonots yay!! thx!
