### PR TITLE
raise error to outside thread rather than main thread

### DIFF
--- a/lib/jvertica.rb
+++ b/lib/jvertica.rb
@@ -181,11 +181,12 @@ class Jvertica
 
       if block_given?
         i, o = IO.pipe
+        copy_stream_thread = Thread.current
         thread = Thread.new do
           begin
             yield(o)
           rescue => e
-            Thread.main.raise e
+            copy_stream_thread.raise e
           end
           o.close
         end


### PR DESCRIPTION
The thread running `copy_stream` may not be the main thread.
So, `Thread.main.raise` must be fixed. 
