### PR TITLE
Support grant query

### DIFF
--- a/lib/jvertica.rb
+++ b/lib/jvertica.rb
@@ -140,6 +140,7 @@ class Jvertica
     when %r{\A\s*drop}miu   then return stmt.execute(query)
     when %r{\A\s*create}miu then return stmt.execute(query)
     when %r{\A\s*set}miu    then return stmt.execute(query)
+    when %r{\A\s*grant}miu  then return stmt.execute(query)
     else rs = stmt.executeQuery(query)
     end
 


### PR DESCRIPTION
When `GRANT` query is executed, the below error happen. So I fixed this.

```
[Vertica][JDBC](11300) A ResultSet was expected but not generated from query "GRANT SELECT ON....". Query not executed.
```
